### PR TITLE
Fix compression enum names

### DIFF
--- a/Assets/DebugShaders/Runtime/Shaders/Normal.shader
+++ b/Assets/DebugShaders/Runtime/Shaders/Normal.shader
@@ -8,7 +8,7 @@ Shader "Debug/Normal"
         [ToggleUI]
         _Remap0to1("Remap 0 to 1", int) = 0
         
-        [Enum(Raw,0 , CompresTo16bit, 1, CompresTo24bit, 2, CompresTo32bit, 3)]
+        [Enum(Raw,0 , CompressTo16bit, 1, CompressTo24bit, 2, CompressTo32bit, 3)]
         _CompressionType("Compression Type", int) = 0
         
         [Enum(RawVec,0 , Half Lambert, 1, CompressionDiff, 2)]


### PR DESCRIPTION
## Summary
- rename `CompresTo*` enum values in Normal.shader to `CompressTo*`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68454cc05b5c8332ad013414fc4e4027